### PR TITLE
Fix some unintentionally broken typings for callbacks

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,6 +1,8 @@
 import {YtResult} from "youtube-node";
 
 declare module "youtube-node" {
+  type Callback = (error?: Error, data?: YtResult) => void;
+
   export class YouTube {
     public constructor();
 
@@ -11,16 +13,16 @@ declare module "youtube-node" {
     public addParam(key: string, value: string): void;
     public addPart(name: string): void;
     public clearParams(): void;
-    public getById(id: string, callback: (validate?: Error, data?: YtResult) => void): void;
-    public getChannelById(id: string, callback: (validate?: Error, data?: YtResult) => void): void;
-    public getPlaylistById(id: string, callback: (validate?: Error, data?: YtResult) => void): void;
-    public getPlaylistItemsById(id: string, maxResults: number, callback: (validate?: Error) => void, data?: YtResult): void;
+    public getById(id: string, callback: Callback): void;
+    public getChannelById(id: string, callback: Callback): void;
+    public getPlaylistById(id: string, callback: Callback): void;
+    public getPlaylistItemsById(id: string, maxResults: number, callback: Callback): void;
     public getParts(): string;
     public getUrl(path: string): string;
     private newError(message: string): Error;
-    public related(id: string, maxResults: number, callback: (validate?: Error) => void, data?: YtResult): void;
-    public request(url: string, callback: (error?: Error, data?: YtResult) => void): void;
-    public search(id: string, maxResults: number, params: Object, callback: (validate?: Error) => void, data?: YtResult): void;
+    public related(id: string, maxResults: number, callback: Callback): void;
+    public request(url: string, callback: Callback): void;
+    public search(id: string, maxResults: number, params: Object, callback: Callback): void;
     public setKey(key: string): void;
     public validate(): Error | null;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -22,6 +22,7 @@ declare module "youtube-node" {
     private newError(message: string): Error;
     public related(id: string, maxResults: number, callback: Callback): void;
     public request(url: string, callback: Callback): void;
+    public search(id: string, maxResults: number, callback: Callback): void;
     public search(id: string, maxResults: number, params: Object, callback: Callback): void;
     public setKey(key: string): void;
     public validate(): Error | null;


### PR DESCRIPTION
For the TypeScript definitions for this library, the function signature for the API calls that take a `callback` argument seem to have been accidentally formatted incorrectly. That is, looking at `search`, the signature _should_ be:

```typescript
function search(
  id: string,
  maxResults: number,
  params: Object,
  callback: (error?: Error, data?: YtResult) => void
);
```

However, the way it's currently written, it's interpreted as:
```typescript
function search(
  id: string,
  maxResults: number,
  params: Object,
  callback: (error?: Error) => void,
  data?: YtResult
);
```

It looked like in addition to `search`, the same issue is also found on `getPlaylistItemsById` and `related`. In order to prevent this typo from happening again, I moved the whole function signature to its own type declaration so it's much simpler to use as a function argument.

Additionally, the `search` function provides an overloaded signature that's used in the example documents, where `params` is skipped and `callback` becomes the third parameter. I've added this overloaded signature.