### PR TITLE
Change clean part and params after request

### DIFF
--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -166,8 +166,6 @@ const YouTube = function () {
     if (validate !== null) {
       callback(validate);
     } else {
-      self.clearParams();
-      self.clearParts();
 
       self.addPart('snippet');
       self.addPart('contentDetails');
@@ -178,6 +176,9 @@ const YouTube = function () {
       self.addParam('id', id);
 
       self.request(self.getUrl('channels'), callback);
+
+      self.clearParams();
+      self.clearParts();
     }
   };
 


### PR DESCRIPTION
Change the clean params to the end of the request, this avoids erroring with the consequent requests